### PR TITLE
Bold post title in chat report messages

### DIFF
--- a/spamhandling.py
+++ b/spamhandling.py
@@ -169,7 +169,7 @@ def handle_spam(post, reasons, why):
 def build_message(post, reasons):
     # This is the main report format. Username and user link are deliberately not separated as with title and post
     # link, because we may want to use "by a deleted user" rather than a username+link.
-    message_format = "{prefix_ms} {{reasons}} ({reason_weight}): [{title}\u202D]({post_url}) by {user} on `{site}`"
+    message_format = "{prefix_ms} {{reasons}} ({reason_weight}): **[{title}\u202D]({post_url})** by {user} on `{site}`"
 
     # Post URL, user URL, and site details are all easy - just data from the post object, transformed a bit
     # via datahandling.


### PR DESCRIPTION
Adds the appropriate mini-Markdown syntax to ensure that the post title is rendered in boldface within the reports posted by SmokeDetector in associated chat rooms. The intention behind this change is to make it easier to identify the link to the post, given strings of indeterminate length and viewports of arbitrary width resulting in wrapping.

Context: https://chat.stackexchange.com/transcript/message/60730004#60730004